### PR TITLE
camunda-bpm-swagger-json version fix

### DIFF
--- a/example/spring-boot/pom.xml
+++ b/example/spring-boot/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.camunda.bpm.extension.swagger</groupId>
       <artifactId>camunda-bpm-swagger-json</artifactId>
-      <version>${project.version}</version>
+      <version>7.8.0</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Using the URL from the README

http://localhost:8080/webjars/swagger-ui/3.1.4/index.html?docExpansion=false&url=/swagger.json
leads to

Failed to load spec

The path to /swagger.json seems to be wrong.