### PR TITLE
bump swagger-maven-plugin dependency to improve generated open api spec

### DIFF
--- a/maven-plugin/generator/src/main/java/org/camunda/bpm/swagger/maven/GenerateSwaggerJsonMojo.java
+++ b/maven-plugin/generator/src/main/java/org/camunda/bpm/swagger/maven/GenerateSwaggerJsonMojo.java
@@ -99,7 +99,7 @@ public class GenerateSwaggerJsonMojo extends AbstractMojo {
   private static final Plugin SWAGGER_PLUGIN = plugin(
     groupId("com.github.kongchen"),
     artifactId("swagger-maven-plugin"),
-    version("3.1.5"),
+    version("3.1.8"),
     Collections.emptyList()
   );
 
@@ -125,6 +125,7 @@ public class GenerateSwaggerJsonMojo extends AbstractMojo {
 
     return element("apiSource",
       element("swaggerDirectory", swaggerDirectory),
+      element("outputFormats", "json,yaml"),
       element("attachSwaggerArtifact", "true"),
       element("springmvc", "false"),
       element("schemes", "http"),


### PR DESCRIPTION
Previously, List<T> generated a response like this:

        "responses" : {
          "200" : {
            "description" : "Request successful.",
            "schema" : {
              "type" : "array",
              "items" : {
                "type" : "object"
              }
            }
          },

With the new version, the type in the returned list is no longer list

        "responses" : {
          "200" : {
            "description" : "Request successful.",
            "schema" : {
              "type" : "array",
              "items" : {
                "$ref" : "#/definitions/ExternalTaskDto"
              }
            }
          },